### PR TITLE
Bugfix/31 output file creation

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ tokio.workspace = true
 thiserror.workspace = true
 regex = "1.12.2"
 derive_builder = "0.20.2"
+libc = "0.2.183"
 
 [dev-dependencies]
 tempfile = "3"

--- a/core/src/util/fs.rs
+++ b/core/src/util/fs.rs
@@ -40,9 +40,7 @@ pub fn create_file_with_user_permissions(path: &str) -> std::io::Result<File> {
     file.set_permissions(Permissions::from_mode(URW_GRW_OR_PERMS))?;
 
     if unsafe { libc::getuid() } == 0 {
-        let parent = Path::new(path)
-            .parent()
-            .unwrap_or_else(|| Path::new("."));
+        let parent = Path::new(path).parent().unwrap_or_else(|| Path::new("."));
         let meta = fs::metadata(parent)?;
         chown(path, Some(meta.uid()), Some(meta.gid()))?;
     }

--- a/core/src/util/fs.rs
+++ b/core/src/util/fs.rs
@@ -1,8 +1,8 @@
 use std::{
     env,
-    fs::{File, OpenOptions, Permissions},
-    os::unix::fs::{PermissionsExt, chown},
-    path::PathBuf,
+    fs::{self, File, OpenOptions, Permissions},
+    os::unix::fs::{MetadataExt, PermissionsExt, chown},
+    path::{Path, PathBuf},
 };
 
 use crate::util::time::get_timestamp_millis;
@@ -24,29 +24,28 @@ pub fn default_iterations_filename(ext: &str) -> String {
     format!("data{}.{}", get_timestamp_millis(), ext)
 }
 
-const ROOT_UID_ENV_VAR: &str = "SUDO_UID";
-const ROOT_GID_ENV_VAR: &str = "SUDO_GID";
 const URW_GRW_OR_PERMS: u32 = 0o664;
 
-/// Creates a file with user permissions even if the current user is root.
+/// Creates a file at `path`, ensuring it is owned by the parent directory's owner.
+///
+/// When running as root, the file ownership is set to match the parent directory
+/// (via `chown`) so the file isn't accidentally left owned by root.
+/// The `getuid()` call is safe, it has no preconditions and always succeeds.
 pub fn create_file_with_user_permissions(path: &str) -> std::io::Result<File> {
     let file = OpenOptions::new()
         .write(true)
         .create(true)
         .truncate(true)
         .open(path)?;
-
     file.set_permissions(Permissions::from_mode(URW_GRW_OR_PERMS))?;
 
-    let uid = env::var(ROOT_UID_ENV_VAR)
-        .ok()
-        .and_then(|v| v.parse::<u32>().ok());
-
-    let gid = env::var(ROOT_GID_ENV_VAR)
-        .ok()
-        .and_then(|v| v.parse::<u32>().ok());
-
-    chown(path, uid, gid)?;
+    if unsafe { libc::getuid() } == 0 {
+        let parent = Path::new(path)
+            .parent()
+            .unwrap_or_else(|| Path::new("."));
+        let meta = fs::metadata(parent)?;
+        chown(path, Some(meta.uid()), Some(meta.gid()))?;
+    }
 
     Ok(file)
 }


### PR DESCRIPTION
This pull request is related to the bug #31, which was causing an error when a user with root privileges was trying to put joule-profiler output file in another user's home directory.

It consists of only one function fix:

```rs
pub fn create_file_with_user_permissions(path: &str) -> std::io::Result<File> {
    let file = OpenOptions::new()
        .write(true)
        .create(true)
        .truncate(true)
        .open(path)?;
    file.set_permissions(Permissions::from_mode(URW_GRW_OR_PERMS))?;

    if unsafe { libc::getuid() } == 0 {
        let parent = Path::new(path)
            .parent()
            .unwrap_or_else(|| Path::new("."));
        let meta = fs::metadata(parent)?;
        chown(path, Some(meta.uid()), Some(meta.gid()))?;
    }

    Ok(file)
}
```

Now the function is checking the uid of the user calling the program, if the user is root, then we must change the output file's group and user.

The call to libc::getuid is unsafe because it uses the libc FFI, but in reality it never returns an error on Linux systems.