### PR TITLE
Bugfix/7 uninstall script not working when piped to bash

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -66,7 +66,7 @@ main() {
 
     # Confirm uninstallation
     echo -n "Do you want to uninstall $BINARY_NAME? [y/N] " >&2
-    read -r reply
+    read -r reply </dev/tty
     if [[ ! $reply =~ ^[Yy]$ ]]; then
         log_info "Uninstallation cancelled"
         exit 0


### PR DESCRIPTION
This pull request is related to the bug #7.

The bug is that the uninstall script is not working when piped to bash, this was due to the fact that stdin is consumed when piped to bash.

To solve that problem, we just need to replace the standard input by the current terminal input.