### PR TITLE
Bugfix/37 runs program as root

### DIFF
--- a/cli/src/commands/profile.rs
+++ b/cli/src/commands/profile.rs
@@ -29,4 +29,8 @@ pub struct ProfileArgs {
     /// Rapl polling frequency in second.
     #[arg(long = "rapl-polling")]
     pub rapl_polling: Option<f64>,
+
+    /// Executes the profiled command with root privileges.
+    #[arg(long = "root")]
+    pub with_root: bool,
 }

--- a/cli/src/commands/profile.rs
+++ b/cli/src/commands/profile.rs
@@ -31,6 +31,6 @@ pub struct ProfileArgs {
     pub rapl_polling: Option<f64>,
 
     /// Executes the profiled command with root privileges if true and Joule Profiler is launched as root.
-    #[arg(long = "root")]
-    pub with_root: bool,
+    #[arg(long = "use-root")]
+    pub use_root: bool,
 }

--- a/cli/src/commands/profile.rs
+++ b/cli/src/commands/profile.rs
@@ -30,7 +30,7 @@ pub struct ProfileArgs {
     #[arg(long = "rapl-polling")]
     pub rapl_polling: Option<f64>,
 
-    /// Executes the profiled command with root privileges.
+    /// Executes the profiled command with root privileges if true and Joule Profiler is launched as root.
     #[arg(long = "root")]
     pub with_root: bool,
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -87,7 +87,7 @@ impl From<CliArgs> for Config {
                 stdout_file: profile_args.stdout_file,
                 cmd: profile_args.cmd,
                 token_pattern: profile_args.token_pattern,
-                with_root: profile_args.with_root,
+                use_root: profile_args.use_root,
             }),
 
             ProfilerCommand::ListSensors => Command::ListSensors,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -87,6 +87,7 @@ impl From<CliArgs> for Config {
                 stdout_file: profile_args.stdout_file,
                 cmd: profile_args.cmd,
                 token_pattern: profile_args.token_pattern,
+                with_root: profile_args.with_root,
             }),
 
             ProfilerCommand::ListSensors => Command::ListSensors,

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -59,6 +59,6 @@ pub struct ProfileConfig {
     #[builder(default = PHASE_TOKEN_DEFAULT_REGEX_PATTERN.to_string())]
     pub token_pattern: String,
 
-    /// Execute the profiled command with root privileges if true.
+    /// Executes the profiled command with root privileges if true and Joule Profiler is launched as root.
     pub with_root: bool,
 }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -12,7 +12,7 @@
 //!     stdout_file: None,
 //!     cmd: vec!["sleep".into(), "1".into()],
 //!     token_pattern: "__[A-Z0-9_]+__".into(),
-//!     with_root: false,
+//!     use_root: false,
 //! };
 //!
 //! let config = Config {
@@ -60,5 +60,5 @@ pub struct ProfileConfig {
     pub token_pattern: String,
 
     /// Executes the profiled command with root privileges if true and Joule Profiler is launched as root.
-    pub with_root: bool,
+    pub use_root: bool,
 }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -12,6 +12,7 @@
 //!     stdout_file: None,
 //!     cmd: vec!["sleep".into(), "1".into()],
 //!     token_pattern: "__[A-Z0-9_]+__".into(),
+//!     with_root: false,
 //! };
 //!
 //! let config = Config {
@@ -57,4 +58,7 @@ pub struct ProfileConfig {
     /// Regex used to detect phase tokens in program output.
     #[builder(default = PHASE_TOKEN_DEFAULT_REGEX_PATTERN.to_string())]
     pub token_pattern: String,
+
+    /// Execute the profiled command with root privileges if true.
+    pub with_root: bool,
 }

--- a/core/src/profiler/error.rs
+++ b/core/src/profiler/error.rs
@@ -30,7 +30,7 @@ pub enum JouleProfilerError {
 
     /// Failed to retrieve `SUDO_USER` environment variable.
     #[error(
-        "Cannot retrieve SUDO_USER environment variable, please retry without root privileges or use \"--root\" CLI argument."
+        "Cannot retrieve SUDO_USER environment variable, please retry without root privileges or use \"--use-root\" CLI argument."
     )]
     CannotRetrieveSudoUser,
 

--- a/core/src/profiler/error.rs
+++ b/core/src/profiler/error.rs
@@ -28,6 +28,20 @@ pub enum JouleProfilerError {
     #[error("Stdout capture failed")]
     StdOutCaptureFail,
 
+    /// Failed to retrieve `SUDO_USER` environment variable.
+    #[error(
+        "Cannot retrieve SUDO_USER environment variable, please retry without root privileges or use \"--root\" CLI argument."
+    )]
+    CannotRetrieveSudoUser,
+
+    /// The environment variable exists but is not parsable into the wanted format.
+    #[error("Unable to parse {0} environment variable.")]
+    CannotParseEnvVariable(String),
+
+    /// Unable to retrieve the current effective user id by it's name with the `getpwnam` libc function.
+    #[error("Unable to retrieve current user id by it's name.")]
+    CannotRetrieveCurrentUserId,
+
     /// Generic I/O error.
     #[error("I/O error")]
     IoError(

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -52,7 +52,7 @@ pub mod types;
 ///     cmd: vec!["echo".to_string(), "hello".to_string()],
 ///     token_pattern: "__PHASE__".to_string(),
 ///     stdout_file: None,
-///     with_root: false,
+///     use_root: false,
 /// };
 ///
 /// let results = profiler.profile(&config).await.unwrap();
@@ -325,7 +325,7 @@ pub fn phase_token_in_line<'a>(regex: &Regex, line: &'a str) -> Option<&'a str> 
 ///
 /// The standard output is piped to be analyzed for phases detection.
 fn spawn_profiled_command(config: &ProfileConfig) -> Result<Child> {
-    let mut command = init_command(&config.cmd, config.with_root)?;
+    let mut command = init_command(&config.cmd, config.use_root)?;
 
     command.spawn().map_err(|err| {
         if err.kind() == ErrorKind::NotFound {
@@ -338,7 +338,7 @@ fn spawn_profiled_command(config: &ProfileConfig) -> Result<Child> {
 
 /// Initializes the command used to spawn the profiled process and handles it's privileges.
 ///
-/// If the current user is root and the parameter `with_root` is true, then the command
+/// If the current user is root and the parameter `use_root` is true, then the command
 /// is spawned with root privileges, else the real user id is retrieved and the process
 /// runs with user privileges. If Joule Profiler is not launched with root privileges,
 /// then the program is spawned with default user privileges.
@@ -346,13 +346,13 @@ fn spawn_profiled_command(config: &ProfileConfig) -> Result<Child> {
 /// An error can occur if:
 /// - The `SUDO_USER` environment variable cannot be retrieved, even so the user is root.
 /// - The user uid cannot be retrieved with it's username provided by the environment variable.  
-pub fn init_command(cmd: &[String], with_root: bool) -> Result<Command> {
+pub fn init_command(cmd: &[String], use_root: bool) -> Result<Command> {
     let mut command = process::Command::new(&cmd[0]);
     if cmd.len() > 1 {
         command.args(&cmd[1..]);
     }
 
-    if geteuid() == 0 && !with_root {
+    if geteuid() == 0 && !use_root {
         let username =
             std::env::var("SUDO_USER").map_err(|_| JouleProfilerError::CannotRetrieveSudoUser)?;
         let uid = get_uid_from_username(&username)?;
@@ -447,7 +447,7 @@ mod tests {
             cmd,
             token_pattern: "__PHASE__".to_string(),
             stdout_file: None,
-            with_root: false,
+            use_root: false,
         }
     }
 
@@ -675,7 +675,7 @@ mod tests {
             cmd: vec!["echo".to_string()],
             token_pattern: "[[invalid[[[regex[[".to_string(),
             stdout_file: None,
-            with_root: false,
+            use_root: false,
         };
         profiler.add_source(MockMetricReader::new());
         let result = profiler.profile(&config).await;

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -7,6 +7,8 @@
 use log::{debug, info, trace};
 use regex::Regex;
 use std::io::BufWriter;
+use std::os::unix::process::CommandExt;
+use std::process::{Child, Command};
 use std::{
     io::{BufRead, BufReader, ErrorKind, Write},
     process::{self, Stdio},
@@ -21,6 +23,7 @@ use crate::profiler::types::{MeasurePhasesReturnType, Phase, ProfilerResults, Re
 use crate::sensor::{Sensor, Sensors};
 use crate::source::{MetricReader, MetricSource, MetricSourceError};
 use crate::util::fs::create_file_with_user_permissions;
+use crate::util::sys::{get_uid_from_username, geteuid, signal};
 use crate::util::time::get_timestamp_micros;
 pub use error::JouleProfilerError;
 
@@ -49,6 +52,7 @@ pub mod types;
 ///     cmd: vec!["echo".to_string(), "hello".to_string()],
 ///     token_pattern: "__PHASE__".to_string(),
 ///     stdout_file: None,
+///     with_root: false,
 /// };
 ///
 /// let results = profiler.profile(&config).await.unwrap();
@@ -178,7 +182,7 @@ impl JouleProfiler {
     /// - The profiler listens for phase token in the standard output of the profiled process and make a measure for every token detected.
     /// - When the program exited, the profiler makes a last measure to compute the last phase metrics.
     ///
-    /// After all the profiling sessions, results are aggregated into a common structure.
+    /// After the profiling, results are aggregated into a common structure.
     async fn measure_phases(&mut self, config: &ProfileConfig) -> Result<MeasurePhasesReturnType> {
         debug!("Compiling phase regex");
 
@@ -320,24 +324,45 @@ pub fn phase_token_in_line<'a>(regex: &Regex, line: &'a str) -> Option<&'a str> 
 /// error is returned if the specified program cannot be found, or a [`JouleProfilerError::CommandExecutionFailed`] otherwise.
 ///
 /// The standard output is piped to be analyzed for phases detection.
-fn spawn_profiled_command(config: &ProfileConfig) -> Result<process::Child> {
-    let mut command = process::Command::new(&config.cmd[0]);
+fn spawn_profiled_command(config: &ProfileConfig) -> Result<Child> {
+    let mut command = init_command(&config.cmd, config.with_root)?;
 
-    if config.cmd.len() > 1 {
-        command.args(&config.cmd[1..]);
+    command.spawn().map_err(|err| {
+        if err.kind() == ErrorKind::NotFound {
+            JouleProfilerError::CommandNotFound(config.cmd[0].clone())
+        } else {
+            JouleProfilerError::CommandExecutionFailed(err.to_string())
+        }
+    })
+}
+
+/// Initializes the command used to spawn the profiled process and handles it's privileges.
+///
+/// If the current user is root and the parameter `with_root` is true, then the command
+/// is spawned with root privileges, else the real user id is retrieved and the process
+/// runs with user privileges. If Joule Profiler is not launched with root privileges,
+/// then the program is spawned with default user privileges.
+///
+/// An error can occur if:
+/// - The `SUDO_USER` environment variable cannot be retrieved, even so the user is root.
+/// - The user uid cannot be retrieved with it's username provided by the environment variable.  
+pub fn init_command(cmd: &[String], with_root: bool) -> Result<Command> {
+    let mut command = process::Command::new(&cmd[0]);
+    if cmd.len() > 1 {
+        command.args(&cmd[1..]);
     }
 
-    command
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .map_err(|err| {
-            if err.kind() == ErrorKind::NotFound {
-                JouleProfilerError::CommandNotFound(config.cmd[0].clone())
-            } else {
-                JouleProfilerError::CommandExecutionFailed(err.to_string())
-            }
-        })
+    if geteuid() == 0 && !with_root {
+        let username =
+            std::env::var("SUDO_USER").map_err(|_| JouleProfilerError::CannotRetrieveSudoUser)?;
+        let uid = get_uid_from_username(&username)?;
+        command.uid(uid);
+    }
+
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::inherit());
+
+    Ok(command)
 }
 
 /// Waits for the sub-process termination, returns the status code of the child.
@@ -372,29 +397,11 @@ fn create_output_sink(path: Option<&String>) -> Result<Box<dyn Write>> {
 ///   '`std::process::Child::id()`' immediately after spawning.
 /// - The process must be owned by the current user (we only signal
 ///   child processes we created).
-/// - Calling '`libc::kill`' is unsafe because it performs a raw syscall.
-///
-/// Race Condition
-///
-/// The target process may terminate between '`spawn()`' and the
-/// 'SIGSTOP' call. In that case, the system call will fail and
-/// an error will be returned.
-///
-/// Errors
 ///
 /// Returns [`JouleProfilerError::ProcessControlFailed`] if the
-/// signal could not be delivered (e.g., invalid PID or already exited).
+/// signal delivery fails.
 fn pause_prosess(pid: i32) -> Result<()> {
-    let result = unsafe { libc::kill(pid, libc::SIGSTOP) };
-
-    if result != 0 {
-        let err = std::io::Error::last_os_error();
-        return Err(JouleProfilerError::ProcessControlFailed(format!(
-            "Failed to SIGSTOP pid {pid}: {err}"
-        )));
-    }
-
-    Ok(())
+    signal(pid, libc::SIGSTOP)
 }
 
 /// Sends `SIGCONT` to resume a previously paused process.
@@ -403,22 +410,11 @@ fn pause_prosess(pid: i32) -> Result<()> {
 ///
 /// - `pid` must refer to a valid, running or stopped child process.
 /// - The process must still exist when the signal is sent.
-/// - `libc::kill` is unsafe because it invokes a raw syscall.
-///
 ///
 /// Returns [`JouleProfilerError::ProcessControlFailed`] if the
 /// signal delivery fails.
 fn resume_process(pid: i32) -> Result<()> {
-    let result = unsafe { libc::kill(pid, libc::SIGCONT) };
-
-    if result != 0 {
-        let err = std::io::Error::last_os_error();
-        return Err(JouleProfilerError::ProcessControlFailed(format!(
-            "Failed to SIGCONT pid {pid}: {err}"
-        )));
-    }
-
-    Ok(())
+    signal(pid, libc::SIGCONT)
 }
 
 #[cfg(test)]
@@ -451,6 +447,7 @@ mod tests {
             cmd,
             token_pattern: "__PHASE__".to_string(),
             stdout_file: None,
+            with_root: false,
         }
     }
 
@@ -678,6 +675,7 @@ mod tests {
             cmd: vec!["echo".to_string()],
             token_pattern: "[[invalid[[[regex[[".to_string(),
             stdout_file: None,
+            with_root: false,
         };
         profiler.add_source(MockMetricReader::new());
         let result = profiler.profile(&config).await;

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -1,2 +1,3 @@
 pub mod fs;
+pub mod sys;
 pub mod time;

--- a/core/src/util/sys.rs
+++ b/core/src/util/sys.rs
@@ -1,0 +1,65 @@
+use std::ffi::{CStr, CString};
+
+use crate::JouleProfilerError;
+
+/// Sends a signal to a process.
+///
+/// SAFETY
+///
+/// - 'pid' must refer to a valid process identifier.
+/// - Calling `libc::kill` is unsafe because it performs a raw syscall using the Linux FFI.
+///
+/// Race Condition
+///
+/// The target process may terminate before the
+/// signal is made. In that case, the system call will fail and
+/// an error will be returned and the signal name will
+/// be retrieved for better error handling.
+///
+/// Errors
+///
+/// Returns [`JouleProfilerError::ProcessControlFailed`] if the
+/// signal could not be delivered (e.g., invalid PID or already exited).
+pub fn signal(pid: i32, sig: i32) -> Result<(), JouleProfilerError> {
+    if unsafe { libc::kill(pid, sig) } != 0 {
+        let sig_name = unsafe {
+            let ptr = libc::strsignal(sig);
+            if ptr.is_null() {
+                "unknown signal".to_string()
+            } else {
+                CStr::from_ptr(ptr).to_string_lossy().to_string()
+            }
+        };
+        Err(JouleProfilerError::ProcessControlFailed(format!(
+            "Cannot send signal {sig_name} to process {pid}"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+/// Gets the effective user id of the current process.
+///
+/// SAFETY
+///
+/// - Calling `libc::geteuid` is unsafe because it performs a raw syscall using the Linux FFI.
+pub fn geteuid() -> u32 {
+    unsafe { libc::geteuid() }
+}
+
+/// Gets the current process' user id from its username.
+///
+/// SAFETY
+///
+/// - Calling `libc::getpwnam` is unsafe because it uses the Linux FFI.
+pub fn get_uid_from_username(username: &str) -> Result<u32, JouleProfilerError> {
+    let cname =
+        CString::new(username).map_err(|_| JouleProfilerError::CannotRetrieveCurrentUserId)?;
+    let passwd = unsafe { libc::getpwnam(cname.as_ptr()) };
+
+    if passwd.is_null() {
+        return Err(JouleProfilerError::CannotRetrieveCurrentUserId);
+    }
+
+    Ok(unsafe { (*passwd).pw_uid })
+}

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -52,6 +52,7 @@ fn config(cmd: Vec<String>, pattern: &str) -> ProfileConfig {
         cmd,
         token_pattern: pattern.to_string(),
         stdout_file: None,
+        with_root: false,
     }
 }
 

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -52,7 +52,7 @@ fn config(cmd: Vec<String>, pattern: &str) -> ProfileConfig {
         cmd,
         token_pattern: pattern.to_string(),
         stdout_file: None,
-        with_root: false,
+        use_root: false,
     }
 }
 

--- a/sources/rapl/src/perf/mod.rs
+++ b/sources/rapl/src/perf/mod.rs
@@ -146,7 +146,7 @@ impl MetricReader for Rapl {
 
     /// Retrieve accumulated metrics since the last reset.
     async fn retrieve(&mut self) -> Result<Self::Type> {
-        trace!("Retrieving RAPL counters",);
+        trace!("Retrieving RAPL counters");
 
         if let Some(begin) = self.begin_snapshot.take()
             && let Some(end) = self.end_snapshot.take()


### PR DESCRIPTION
When Joule Profiler was running with root privileges, then the profiled command was also running as root, thus adding a major security issue.

This pull request fixes this issue by adding a `--use-root` flag to the CLI and a `use_root` field in the profiling configuration.

If this flag is set to true and Joule Profiler is executed as root, then the profiled command is still executed as root, but if the flag is set to false, then the effective user id is retrieved and the program is executed as a regular user.

If the profiled command is preceded by `sudo`, then the flag is not required because it is already executing as root user.

The main purpose is that if a user needs to run Joule Profiler as root, the profiled command is executed as regular user, unless specified.