### PR TITLE
Refactor/40 rename phase to profile mode

### DIFF
--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     let rapl_path = cli.rapl_path.as_deref();
     let rapl_sockets_spec = parse_sockets_spec(cli.sockets.as_deref());
     let rapl_polling = match &cli.command {
-        ProfilerCommand::Phases(phases_args) => phases_args.rapl_polling,
+        ProfilerCommand::Profile(phases_args) => phases_args.rapl_polling,
         ProfilerCommand::ListSensors => None,
     };
 

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     let rapl_path = cli.rapl_path.as_deref();
     let rapl_sockets_spec = parse_sockets_spec(cli.sockets.as_deref());
     let rapl_polling = match &cli.command {
-        ProfilerCommand::Profile(phases_args) => phases_args.rapl_polling,
+        ProfilerCommand::Profile(profile_args) => profile_args.rapl_polling,
         ProfilerCommand::ListSensors => None,
     };
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,13 +1,13 @@
-use crate::commands::phases::PhasesArgs;
+use crate::commands::profile::ProfileArgs;
 use clap::Subcommand;
 
-pub mod phases;
+pub mod profile;
 
-/// Subcommands of joule-profiler
+/// Subcommands of joule-profiler.
 #[derive(Subcommand, Debug)]
 pub enum ProfilerCommand {
-    /// Phase-based measurement mode (with start/end tokens).
-    Phases(PhasesArgs),
+    /// Profiling mode, executes a command and profiles it.
+    Profile(ProfileArgs),
 
     /// List available sensors.
     ListSensors,

--- a/cli/src/commands/profile.rs
+++ b/cli/src/commands/profile.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 
-/// Arguments for Phase-based mode
+/// Arguments for profiling mode.
 #[derive(Parser, Debug)]
-pub struct PhasesArgs {
+pub struct ProfileArgs {
     /// Regex pattern to detect phase tokens in program output.
     ///
     /// Matches tokens in stdout; if the pattern has a capture group, the

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -83,10 +83,10 @@ impl CliArgs {
 impl From<CliArgs> for Config {
     fn from(cli_args: CliArgs) -> Self {
         let command = match cli_args.command {
-            ProfilerCommand::Profile(phases) => Command::Profile(ProfileConfig {
-                stdout_file: phases.stdout_file,
-                cmd: phases.cmd,
-                token_pattern: phases.token_pattern,
+            ProfilerCommand::Profile(profile_args) => Command::Profile(ProfileConfig {
+                stdout_file: profile_args.stdout_file,
+                cmd: profile_args.cmd,
+                token_pattern: profile_args.token_pattern,
             }),
 
             ProfilerCommand::ListSensors => Command::ListSensors,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -83,7 +83,7 @@ impl CliArgs {
 impl From<CliArgs> for Config {
     fn from(cli_args: CliArgs) -> Self {
         let command = match cli_args.command {
-            ProfilerCommand::Phases(phases) => Command::Profile(ProfileConfig {
+            ProfilerCommand::Profile(phases) => Command::Profile(ProfileConfig {
                 stdout_file: phases.stdout_file,
                 cmd: phases.cmd,
                 token_pattern: phases.token_pattern,


### PR DESCRIPTION
This pull request is renaming the `phase` command to `profile`, which is more relevant of program profiling.

To profile a command, now it looks like:
```
joule-profiler profile -- sleep 1
```