### PR TITLE
feat: added MetricValue to support various metric types

### DIFF
--- a/cli/src/output/formats/csv.rs
+++ b/cli/src/output/formats/csv.rs
@@ -166,12 +166,7 @@ mod tests {
     }
 
     fn metric(name: &str, value: u64) -> Metric {
-        Metric {
-            name: name.to_string(),
-            value,
-            unit: unit(),
-            source: "rapl".to_string(),
-        }
+        Metric::new(name.to_string(), value, unit(), "rapl".to_string())
     }
 
     fn phase(

--- a/cli/src/output/formats/csv.rs
+++ b/cli/src/output/formats/csv.rs
@@ -166,7 +166,7 @@ mod tests {
     }
 
     fn metric(name: &str, value: u64) -> Metric {
-        Metric::new(name.to_string(), value, unit(), "rapl".to_string())
+        Metric::new(name, value, unit(), "rapl")
     }
 
     fn phase(
@@ -333,16 +333,8 @@ mod tests {
     fn list_sensors_writes_header_and_one_row_per_sensor() {
         let (mut csv, tmp) = csv_to_tempfile();
         let sensors = vec![
-            Sensor {
-                name: "PKG".into(),
-                unit: unit(),
-                source: "rapl".into(),
-            },
-            Sensor {
-                name: "DRAM".into(),
-                unit: unit(),
-                source: "rapl".into(),
-            },
+            Sensor::new("PKG", unit(), "rapl"),
+            Sensor::new("DRAM", unit(), "rapl"),
         ];
         csv.list_sensors(&sensors).unwrap();
         let content = read(&tmp);

--- a/core/src/aggregate/metric.rs
+++ b/core/src/aggregate/metric.rs
@@ -11,12 +11,8 @@ use crate::unit::MetricUnit;
 /// ```
 /// use joule_profiler_core::{types::Metric, unit::{MetricUnit, Unit, UnitPrefix}};
 ///
-/// let energy = Metric {
-///     name: "energy_pkg".to_string(),
-///     value: 123456,
-///     unit: MetricUnit { unit: Unit::Joule, prefix: UnitPrefix::Micro },
-///     source: "rapl".to_string(),
-/// };
+/// let unit = MetricUnit { unit: Unit::Joule, prefix: UnitPrefix::Micro };
+/// let energy = Metric::new("energy_pkg", 123456u64, unit, "rapl");
 /// ```
 #[derive(Debug, Serialize, Clone)]
 pub struct Metric {
@@ -34,15 +30,17 @@ pub struct Metric {
 }
 
 impl Metric {
-    pub fn new<T>(name: String, value: T, unit: MetricUnit, source: String) -> Self
+    pub fn new<N, V, S>(name: N, value: V, unit: MetricUnit, source: S) -> Self
     where
-        T: Into<MetricValue>,
+        N: Into<String>,
+        V: Into<MetricValue>,
+        S: Into<String>,
     {
-        Metric {
-            name,
+        Self {
+            name: name.into(),
             value: value.into(),
             unit,
-            source,
+            source: source.into(),
         }
     }
 }

--- a/core/src/aggregate/metric.rs
+++ b/core/src/aggregate/metric.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use serde::Serialize;
 
 use crate::unit::MetricUnit;
@@ -22,7 +24,7 @@ pub struct Metric {
     pub name: String,
 
     /// The numeric value of the metric.
-    pub value: u64,
+    pub value: MetricValue,
 
     /// The unit of measurement.
     pub unit: MetricUnit,
@@ -31,5 +33,55 @@ pub struct Metric {
     pub source: String,
 }
 
+impl Metric {
+    pub fn new<T>(name: String, value: T, unit: MetricUnit, source: String) -> Self
+    where
+        T: Into<MetricValue>,
+    {
+        Metric {
+            name,
+            value: value.into(),
+            unit,
+            source,
+        }
+    }
+}
+
 /// A collection of metrics.
 pub type Metrics = Vec<Metric>;
+
+/// Enum representing the value of a metric,
+/// with this enum, a metric can be a signed or
+/// unsigned integer or a float.
+#[derive(Debug, Serialize, Clone, Copy, PartialEq)]
+pub enum MetricValue {
+    UnsignedInteger(u64),
+    SignedInteger(i64),
+    Float(f64),
+}
+
+impl From<u64> for MetricValue {
+    fn from(v: u64) -> Self {
+        Self::UnsignedInteger(v)
+    }
+}
+impl From<i64> for MetricValue {
+    fn from(v: i64) -> Self {
+        Self::SignedInteger(v)
+    }
+}
+impl From<f64> for MetricValue {
+    fn from(v: f64) -> Self {
+        Self::Float(v)
+    }
+}
+
+impl Display for MetricValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsignedInteger(v) => v.fmt(f),
+            Self::SignedInteger(v) => v.fmt(f),
+            Self::Float(v) => v.fmt(f),
+        }
+    }
+}

--- a/core/src/aggregate/mod.rs
+++ b/core/src/aggregate/mod.rs
@@ -10,4 +10,4 @@ mod metric;
 pub(crate) mod phase;
 pub(crate) mod sensor_result;
 
-pub use metric::{Metric, Metrics};
+pub use metric::{Metric, MetricValue, Metrics};

--- a/core/src/aggregate/sensor_result.rs
+++ b/core/src/aggregate/sensor_result.rs
@@ -46,7 +46,7 @@ mod tests {
             unit: Unit::Joule,
             prefix: UnitPrefix::Micro,
         };
-        Metric::new("energy_pkg".to_string(), value, unit, "rapl".to_string())
+        Metric::new("energy_pkg", value, unit, "rapl")
     }
 
     fn phase(metrics: Vec<Metric>) -> SensorPhase {

--- a/core/src/aggregate/sensor_result.rs
+++ b/core/src/aggregate/sensor_result.rs
@@ -38,19 +38,15 @@ impl Add for SensorResult {
 mod tests {
     use super::*;
     use crate::aggregate::phase::SensorPhase;
-    use crate::types::Metric;
+    use crate::types::{Metric, MetricValue};
     use crate::unit::{MetricUnit, Unit, UnitPrefix};
 
     fn metric(value: u64) -> Metric {
-        Metric {
-            name: "energy_pkg".to_string(),
-            value,
-            unit: MetricUnit {
-                unit: Unit::Joule,
-                prefix: UnitPrefix::Micro,
-            },
-            source: "rapl".to_string(),
-        }
+        let unit = MetricUnit {
+            unit: Unit::Joule,
+            prefix: UnitPrefix::Micro,
+        };
+        Metric::new("energy_pkg".to_string(), value, unit, "rapl".to_string())
     }
 
     fn phase(metrics: Vec<Metric>) -> SensorPhase {
@@ -71,7 +67,10 @@ mod tests {
         let r = result(vec![phase(vec![metric(100)])]);
         let merged = SensorResult::merge(vec![r]).unwrap();
         assert_eq!(merged.phases.len(), 1);
-        assert_eq!(merged.phases[0].metrics[0].value, 100);
+        assert_eq!(
+            merged.phases[0].metrics[0].value,
+            MetricValue::UnsignedInteger(100)
+        );
     }
 
     #[test]
@@ -81,7 +80,13 @@ mod tests {
         let merged = SensorResult::merge(vec![r1, r2]).unwrap();
 
         assert_eq!(merged.phases[0].metrics.len(), 2);
-        assert_eq!(merged.phases[0].metrics[0].value, 100);
-        assert_eq!(merged.phases[0].metrics[1].value, 200);
+        assert_eq!(
+            merged.phases[0].metrics[0].value,
+            MetricValue::UnsignedInteger(100)
+        );
+        assert_eq!(
+            merged.phases[0].metrics[1].value,
+            MetricValue::UnsignedInteger(200)
+        );
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,7 +14,7 @@ pub use profiler::{JouleProfiler, JouleProfilerError};
 
 pub mod unit;
 pub mod types {
-    pub use super::aggregate::{Metric, Metrics, sensor_result::SensorResult};
+    pub use super::aggregate::{Metric, MetricValue, Metrics, sensor_result::SensorResult};
     pub use super::phase::PhaseToken;
     pub use super::profiler::types::{Phase, Phases, ProfilerResults};
 }

--- a/core/src/profiler/error.rs
+++ b/core/src/profiler/error.rs
@@ -42,6 +42,10 @@ pub enum JouleProfilerError {
     #[error("Unable to retrieve current user id by it's name.")]
     CannotRetrieveCurrentUserId,
 
+    /// Cannot convert string to a known metric unit.
+    #[error("Invalid metric unit: {0}")]
+    InvalidUnit(String),
+
     /// Generic I/O error.
     #[error("I/O error")]
     IoError(

--- a/core/src/sensor.rs
+++ b/core/src/sensor.rs
@@ -25,11 +25,8 @@ use crate::unit::MetricUnit;
 ///     unit: Unit::Joule,
 /// };
 ///
-/// let sensor = Sensor {
-///     name: "CORE-0".to_string(),
-///     unit: micro_joule_unit,
-///     source: "powercap".to_string(),
-/// };
+/// let sensor = Sensor::new("CORE-0", micro_joule_unit, "powercap");
+///
 /// assert_eq!(sensor.name, "CORE-0");
 /// assert_eq!(sensor.unit.to_string(), "µJ");
 /// assert_eq!(sensor.source, "powercap");
@@ -44,6 +41,20 @@ pub struct Sensor {
 
     /// The metric source associated to the sensor.
     pub source: String,
+}
+
+impl Sensor {
+    pub fn new<N, S>(name: N, unit: MetricUnit, source: S) -> Self
+    where
+        N: Into<String>,
+        S: Into<String>,
+    {
+        Self {
+            name: name.into(),
+            unit,
+            source: source.into(),
+        }
+    }
 }
 
 /// A collection of sensors.

--- a/core/src/unit.rs
+++ b/core/src/unit.rs
@@ -162,13 +162,55 @@ mod tests {
 
     #[test]
     fn test_valid_conversion() {
-        assert_eq!(parse("J"),  MetricUnit { prefix: UnitPrefix::None,  unit: Unit::Joule });
-        assert_eq!(parse("mW"), MetricUnit { prefix: UnitPrefix::Milli, unit: Unit::Watt });
-        assert_eq!(parse("ns"), MetricUnit { prefix: UnitPrefix::Nano,  unit: Unit::Second });
-        assert_eq!(parse("kB"), MetricUnit { prefix: UnitPrefix::Kilo,  unit: Unit::Byte });
-        assert_eq!(parse("uJ"), MetricUnit { prefix: UnitPrefix::Micro, unit: Unit::Joule });
-        assert_eq!(parse("µJ"), MetricUnit { prefix: UnitPrefix::Micro, unit: Unit::Joule });
-        assert_eq!(parse("count"), MetricUnit { prefix: UnitPrefix::None, unit: Unit::Count });
+        assert_eq!(
+            parse("J"),
+            MetricUnit {
+                prefix: UnitPrefix::None,
+                unit: Unit::Joule
+            }
+        );
+        assert_eq!(
+            parse("mW"),
+            MetricUnit {
+                prefix: UnitPrefix::Milli,
+                unit: Unit::Watt
+            }
+        );
+        assert_eq!(
+            parse("ns"),
+            MetricUnit {
+                prefix: UnitPrefix::Nano,
+                unit: Unit::Second
+            }
+        );
+        assert_eq!(
+            parse("kB"),
+            MetricUnit {
+                prefix: UnitPrefix::Kilo,
+                unit: Unit::Byte
+            }
+        );
+        assert_eq!(
+            parse("uJ"),
+            MetricUnit {
+                prefix: UnitPrefix::Micro,
+                unit: Unit::Joule
+            }
+        );
+        assert_eq!(
+            parse("µJ"),
+            MetricUnit {
+                prefix: UnitPrefix::Micro,
+                unit: Unit::Joule
+            }
+        );
+        assert_eq!(
+            parse("count"),
+            MetricUnit {
+                prefix: UnitPrefix::None,
+                unit: Unit::Count
+            }
+        );
     }
 
     #[test]

--- a/core/src/unit.rs
+++ b/core/src/unit.rs
@@ -151,3 +151,38 @@ impl TryFrom<&str> for MetricUnit {
         Ok(MetricUnit { prefix, unit })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(s: &str) -> MetricUnit {
+        MetricUnit::try_from(s).unwrap()
+    }
+
+    #[test]
+    fn test_valid_conversion() {
+        assert_eq!(parse("J"),  MetricUnit { prefix: UnitPrefix::None,  unit: Unit::Joule });
+        assert_eq!(parse("mW"), MetricUnit { prefix: UnitPrefix::Milli, unit: Unit::Watt });
+        assert_eq!(parse("ns"), MetricUnit { prefix: UnitPrefix::Nano,  unit: Unit::Second });
+        assert_eq!(parse("kB"), MetricUnit { prefix: UnitPrefix::Kilo,  unit: Unit::Byte });
+        assert_eq!(parse("uJ"), MetricUnit { prefix: UnitPrefix::Micro, unit: Unit::Joule });
+        assert_eq!(parse("µJ"), MetricUnit { prefix: UnitPrefix::Micro, unit: Unit::Joule });
+        assert_eq!(parse("count"), MetricUnit { prefix: UnitPrefix::None, unit: Unit::Count });
+    }
+
+    #[test]
+    fn test_invalid_conversion() {
+        assert!(MetricUnit::try_from("").is_err());
+        assert!(MetricUnit::try_from("Hz").is_err());
+        assert!(MetricUnit::try_from("k").is_err());
+        assert!(MetricUnit::try_from("kcount").is_err());
+    }
+
+    #[test]
+    fn test_backward_conversion() {
+        for s in ["J", "mW", "ns", "kB", "GJ", "count", "%"] {
+            assert_eq!(parse(s).to_string(), s);
+        }
+    }
+}

--- a/core/src/unit.rs
+++ b/core/src/unit.rs
@@ -6,6 +6,8 @@
 use serde::{Serialize, Serializer};
 use std::fmt::Display;
 
+use crate::JouleProfilerError;
+
 /// SI prefixes used to scale metric units.
 #[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
 pub enum UnitPrefix {
@@ -102,5 +104,50 @@ impl Serialize for MetricUnit {
 impl Display for MetricUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}{}", self.prefix, self.unit)
+    }
+}
+
+const PREFIXES: &[(&str, UnitPrefix)] = &[
+    ("n", UnitPrefix::Nano),
+    ("µ", UnitPrefix::Micro),
+    ("u", UnitPrefix::Micro),
+    ("m", UnitPrefix::Milli),
+    ("k", UnitPrefix::Kilo),
+    ("M", UnitPrefix::Mega),
+    ("G", UnitPrefix::Giga),
+];
+
+impl TryFrom<&str> for MetricUnit {
+    type Error = JouleProfilerError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        if s.is_empty() {
+            return Err(JouleProfilerError::InvalidUnit(s.into()));
+        }
+
+        let (prefix, unit_str) = PREFIXES
+            .iter()
+            .find_map(|(p, prefix)| s.strip_prefix(p).map(|stripped| (*prefix, stripped)))
+            .unwrap_or((UnitPrefix::None, s));
+
+        if unit_str.is_empty() {
+            return Err(JouleProfilerError::InvalidUnit(s.into()));
+        }
+
+        let unit = match unit_str {
+            "J" => Unit::Joule,
+            "W" => Unit::Watt,
+            "s" => Unit::Second,
+            "count" => Unit::Count,
+            "B" => Unit::Byte,
+            "%" => Unit::Percent,
+            _ => return Err(JouleProfilerError::InvalidUnit(s.into())),
+        };
+
+        if matches!(unit, Unit::Count) && prefix != UnitPrefix::None {
+            return Err(JouleProfilerError::InvalidUnit(s.into()));
+        }
+
+        Ok(MetricUnit { prefix, unit })
     }
 }

--- a/sources/nvml/src/hardware.rs
+++ b/sources/nvml/src/hardware.rs
@@ -38,11 +38,11 @@ impl NvmlHardware for NvmlWrapperHardware {
     fn get_sensors(&self) -> Result<Sensors> {
         (0..self.devices_max_index)
             .map(|i| {
-                Ok(Sensor {
-                    name: format!("GPU-{i}"),
-                    unit: MILLI_JOULE_UNIT,
-                    source: NVML_SOURCE_NAME.to_string(),
-                })
+                Ok(Sensor::new(
+                    format!("GPU-{i}"),
+                    MILLI_JOULE_UNIT,
+                    NVML_SOURCE_NAME,
+                ))
             })
             .collect::<Result<_>>()
     }

--- a/sources/nvml/src/lib.rs
+++ b/sources/nvml/src/lib.rs
@@ -127,7 +127,7 @@ impl<H: NvmlHardware + 'static> MetricReader for Nvml<H> {
                     format!("GPU-{device_index}"),
                     energy,
                     MILLI_JOULE_UNIT,
-                    Self::get_name().to_string(),
+                    Self::get_name(),
                 )
             })
             .collect())
@@ -179,11 +179,7 @@ mod tests {
 
     fn sensors(count: u32) -> Sensors {
         (0..count)
-            .map(|i| Sensor {
-                name: format!("GPU-{i}"),
-                unit: MILLI_JOULE_UNIT,
-                source: NVML_SOURCE_NAME.to_string(),
-            })
+            .map(|i| Sensor::new(format!("GPU-{i}"), MILLI_JOULE_UNIT, NVML_SOURCE_NAME))
             .collect()
     }
 

--- a/sources/nvml/src/lib.rs
+++ b/sources/nvml/src/lib.rs
@@ -122,11 +122,13 @@ impl<H: NvmlHardware + 'static> MetricReader for Nvml<H> {
         Ok(diff
             .gpus_energy
             .into_iter()
-            .map(|(device_index, energy)| Metric {
-                name: format!("GPU-{device_index}"),
-                value: energy,
-                unit: MILLI_JOULE_UNIT,
-                source: NVML_SOURCE_NAME.to_string(),
+            .map(|(device_index, energy)| {
+                Metric::new(
+                    format!("GPU-{device_index}"),
+                    energy,
+                    MILLI_JOULE_UNIT,
+                    Self::get_name().to_string(),
+                )
             })
             .collect())
     }
@@ -164,7 +166,7 @@ impl<H: NvmlHardware + 'static> Nvml<H> {
 
 #[cfg(test)]
 mod tests {
-    use joule_profiler_core::sensor::Sensor;
+    use joule_profiler_core::{sensor::Sensor, types::MetricValue};
 
     use super::*;
     use crate::{hardware::MockNvmlHardware, snapshot::NvmlSnapshot};
@@ -324,10 +326,10 @@ mod tests {
 
         assert_eq!(metrics.len(), 2);
         assert_eq!(metrics[0].name, "GPU-0");
-        assert_eq!(metrics[0].value, 100);
+        assert_eq!(metrics[0].value, MetricValue::UnsignedInteger(100));
         assert_eq!(metrics[0].unit, MILLI_JOULE_UNIT);
         assert_eq!(metrics[1].name, "GPU-1");
-        assert_eq!(metrics[1].value, 200);
+        assert_eq!(metrics[1].value, MetricValue::UnsignedInteger(200));
         assert_eq!(metrics[1].unit, MILLI_JOULE_UNIT);
     }
 

--- a/sources/perf_event/src/event.rs
+++ b/sources/perf_event/src/event.rs
@@ -41,6 +41,17 @@ impl Display for Event {
     }
 }
 
+impl From<Event> for String {
+    fn from(event: Event) -> Self {
+        match event {
+            Event::CpuCycles => "CPU_CYCLES".into(),
+            Event::Instructions => "INSTRUCTIONS".into(),
+            Event::CacheMisses => "CACHE_MISSES".into(),
+            Event::BranchMisses => "BRANCH_MISSES".into(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sources/perf_event/src/lib.rs
+++ b/sources/perf_event/src/lib.rs
@@ -99,11 +99,7 @@ impl<H: PerfEventHardware + 'static> MetricReader for PerfEvent<H> {
             .iter()
             .map(|event| {
                 trace!("Registering sensor: {event}");
-                Sensor {
-                    name: event.to_string(),
-                    source: Self::get_name().to_string(),
-                    unit: PERF_EVENT_METRIC_UNIT,
-                }
+                Sensor::new(*event, PERF_EVENT_METRIC_UNIT, Self::get_name())
             })
             .collect();
 
@@ -122,12 +118,7 @@ impl<H: PerfEventHardware + 'static> MetricReader for PerfEvent<H> {
             .metrics
             .into_iter()
             .map(|(event, counter)| {
-                Metric::new(
-                    event.to_string(),
-                    counter,
-                    PERF_EVENT_METRIC_UNIT,
-                    Self::get_name().to_string(),
-                )
+                Metric::new(event, counter, PERF_EVENT_METRIC_UNIT, Self::get_name())
             })
             .collect())
     }

--- a/sources/perf_event/src/lib.rs
+++ b/sources/perf_event/src/lib.rs
@@ -121,11 +121,13 @@ impl<H: PerfEventHardware + 'static> MetricReader for PerfEvent<H> {
         Ok(diff
             .metrics
             .into_iter()
-            .map(|(event, counter)| Metric {
-                name: event.to_string(),
-                source: Self::get_name().to_string(),
-                value: counter,
-                unit: PERF_EVENT_METRIC_UNIT,
+            .map(|(event, counter)| {
+                Metric::new(
+                    event.to_string(),
+                    counter,
+                    PERF_EVENT_METRIC_UNIT,
+                    Self::get_name().to_string(),
+                )
             })
             .collect())
     }
@@ -137,6 +139,8 @@ impl<H: PerfEventHardware + 'static> MetricReader for PerfEvent<H> {
 
 #[cfg(test)]
 mod tests {
+    use joule_profiler_core::types::MetricValue;
+
     use super::*;
     use crate::{event::Event, hardware::MockPerfEventHardware, snapshot::Snapshot};
 
@@ -270,7 +274,7 @@ mod tests {
             .find(|m| m.name == Event::CpuCycles.to_string())
             .unwrap();
 
-        assert_eq!(cycles.value, 500);
+        assert_eq!(cycles.value, MetricValue::UnsignedInteger(500));
         assert_eq!(cycles.unit, PERF_EVENT_METRIC_UNIT);
     }
 }

--- a/sources/rapl/src/perf/mod.rs
+++ b/sources/rapl/src/perf/mod.rs
@@ -169,11 +169,7 @@ impl MetricReader for Rapl {
                 socket.domains.iter().map(|domain| {
                     let domain_name = domain.get_name(socket.id);
                     trace!("Registering sensor: {domain_name}");
-                    Sensor {
-                        name: domain_name,
-                        unit: MICRO_JOULE_UNIT,
-                        source: Self::get_name().to_string(),
-                    }
+                    Sensor::new(domain_name, MICRO_JOULE_UNIT, Self::get_name())
                 })
             })
             .collect();
@@ -197,7 +193,7 @@ impl MetricReader for Rapl {
                             domain.domain_type.to_string_socket(socket.id),
                             micro_joules,
                             MICRO_JOULE_UNIT,
-                            Self::get_name().to_string(),
+                            Self::get_name(),
                         ))
                     } else {
                         None

--- a/sources/rapl/src/perf/mod.rs
+++ b/sources/rapl/src/perf/mod.rs
@@ -193,12 +193,12 @@ impl MetricReader for Rapl {
                     if let Some(metric) = diff.get(&domain_index) {
                         let joules = domain.compute_scale(*metric);
                         let micro_joules = joules_to_micro_joules(joules);
-                        Some(Metric {
-                            name: domain.domain_type.to_string_socket(socket.id),
-                            value: micro_joules,
-                            unit: MICRO_JOULE_UNIT,
-                            source: PERF_SOURCE_NAME.to_string(),
-                        })
+                        Some(Metric::new(
+                            domain.domain_type.to_string_socket(socket.id),
+                            micro_joules,
+                            MICRO_JOULE_UNIT,
+                            Self::get_name().to_string(),
+                        ))
                     } else {
                         None
                     }

--- a/sources/rapl/src/powercap/mod.rs
+++ b/sources/rapl/src/powercap/mod.rs
@@ -289,11 +289,13 @@ impl MetricReader for Rapl {
         Ok(snapshot
             .metrics
             .into_iter()
-            .map(|((domain, socket), value)| Metric {
-                name: domain.to_string_socket(socket),
-                value,
-                unit: MICRO_JOULE_UNIT,
-                source: POWERCAP_SOURCE_NAME.to_string(),
+            .map(|((domain, socket), value)| {
+                Metric::new(
+                    domain.to_string_socket(socket),
+                    value,
+                    MICRO_JOULE_UNIT,
+                    Self::get_name().to_string(),
+                )
             })
             .collect())
     }

--- a/sources/rapl/src/powercap/mod.rs
+++ b/sources/rapl/src/powercap/mod.rs
@@ -274,11 +274,7 @@ impl MetricReader for Rapl {
             .iter()
             .map(|domain| {
                 trace!("Registering sensor: {}", domain.get_name());
-                Sensor {
-                    name: domain.get_name(),
-                    unit: MICRO_JOULE_UNIT,
-                    source: Self::get_name().to_string(),
-                }
+                Sensor::new(domain.get_name(), MICRO_JOULE_UNIT, Self::get_name())
             })
             .collect();
 
@@ -294,7 +290,7 @@ impl MetricReader for Rapl {
                     domain.to_string_socket(socket),
                     value,
                     MICRO_JOULE_UNIT,
-                    Self::get_name().to_string(),
+                    Self::get_name(),
                 )
             })
             .collect())


### PR DESCRIPTION
This pull request adds a MetricValue enum, representing the different types a metric can be.

```rs
pub enum MetricValue {
    UnsignedInteger(u64),
    SignedInteger(i64),
    Float(f64),
}
```

It implements Copy for zero cost abstraction and From<T> for T in u64, i64, f64 to use the rust type inference and instanciate metrics in the best way

```rs
impl Metric {
    pub fn new<N, V, S>(name: N, value: V, unit: MetricUnit, source: S) -> Self
    where
        N: Into<String>,
        V: Into<MetricValue>,
        S: Into<String>,
    {
        Self {
            name: name.into(),
            value: value.into(),
            unit,
            source: source.into(),
        }
    }
}
```

We can also implement the Sensor instanciation function the same way:
```rs
impl Sensor {
    pub fn new<N, S>(name: N, unit: MetricUnit, source: S) -> Self
    where
        N: Into<String>,
        S: Into<String>,
    {
        Self {
            name: name.into(),
            unit,
            source: source.into(),
        }
    }
}
```