### PR TITLE
Feat/44 microsecond timestamps

### DIFF
--- a/cli/src/output/formats/csv.rs
+++ b/cli/src/output/formats/csv.rs
@@ -266,7 +266,7 @@ mod tests {
         csv.display_results(&["my_cmd".into(), "--flag".into()], "MY_PATTERN", &iter)
             .unwrap();
         let content = read(&tmp);
-        assert!(content.contains("500")); // duration_ms
+        assert!(content.contains("500")); // duration_us
         assert!(content.contains("MY_PATTERN"));
         assert!(content.contains("my_cmd --flag"));
         assert!(content.contains("3")); // exit_code

--- a/core/src/phase.rs
+++ b/core/src/phase.rs
@@ -49,7 +49,7 @@ pub struct PhaseInfo {
     /// Phase token detected.
     pub token: PhaseToken,
 
-    /// Timestamp in milliseconds.
+    /// Timestamp in microseconds.
     pub timestamp: u128,
 
     /// Optional line number in output where token was detected.

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -21,7 +21,7 @@ use crate::profiler::types::{MeasurePhasesReturnType, Phase, ProfilerResults, Re
 use crate::sensor::{Sensor, Sensors};
 use crate::source::{MetricReader, MetricSource, MetricSourceError};
 use crate::util::fs::create_file_with_user_permissions;
-use crate::util::time::get_timestamp_millis;
+use crate::util::time::get_timestamp_micros;
 pub use error::JouleProfilerError;
 
 pub mod types;
@@ -133,7 +133,7 @@ impl JouleProfiler {
                     start_token: d1.token.clone(),
                     end_token: d2.token.clone(),
                     timestamp: d1.timestamp,
-                    duration_ms: d2.timestamp - d1.timestamp,
+                    duration_ms: (d2.timestamp - d1.timestamp) / 1000,
                     start_token_line: d1.line_number,
                     end_token_line: d2.line_number,
                 }
@@ -205,7 +205,7 @@ impl JouleProfiler {
 
         self.orchestrator.measure().await?;
 
-        let begin_timestamp = get_timestamp_millis();
+        let begin_timestamp = get_timestamp_micros();
         trace!("Begin timestamp: {begin_timestamp}");
 
         resume_process(pid)?;
@@ -222,13 +222,13 @@ impl JouleProfiler {
 
         sink.flush()?;
 
-        let end_timestamp = get_timestamp_millis();
+        let end_timestamp = get_timestamp_micros();
         trace!("End timestamp: {end_timestamp}");
 
         self.orchestrator.measure().await?;
         self.orchestrator.new_phase().await?;
 
-        let duration_ms = end_timestamp - begin_timestamp;
+        let duration_ms = (end_timestamp - begin_timestamp) / 1000;
 
         detected_phases.push(PhaseInfo::end(end_timestamp));
 
@@ -290,7 +290,7 @@ impl JouleProfiler {
             writeln!(sink, "{line}")?;
 
             if let Some(token) = phase_token_in_line(regex, &line) {
-                let phase_timestamp = get_timestamp_millis();
+                let phase_timestamp = get_timestamp_micros();
 
                 debug!("Detected phase at line {line_number}, token '{token}'");
 

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -113,7 +113,7 @@ impl JouleProfiler {
         self.orchestrator.run(sources)?;
 
         info!("Starting measurements");
-        let (duration_ms, timestamp, exit_code, detected_phases) =
+        let (command_duration_ms, timestamp, exit_code, detected_phases) =
             self.measure_phases(config).await?;
 
         let (sources_results, sources) = self.orchestrator.finalize().await?;
@@ -149,7 +149,7 @@ impl JouleProfiler {
                 start_token: PhaseToken::Start,
                 end_token: PhaseToken::End,
                 timestamp,
-                duration_ms,
+                duration_ms: command_duration_ms,
                 start_token_line: None,
                 end_token_line: None,
             };
@@ -159,7 +159,7 @@ impl JouleProfiler {
         debug!("Collected {} sensor phase(s)", phases.len());
         Ok(ProfilerResults {
             timestamp,
-            duration_ms,
+            duration_ms: command_duration_ms,
             exit_code,
             phases,
         })
@@ -234,10 +234,7 @@ impl JouleProfiler {
 
         let exit_code = wait_for_child_exit(&mut child)?;
 
-        info!(
-            "Command finished: duration={} ms exit_code={}",
-            duration_ms, exit_code
-        );
+        info!("Command finished: duration={duration_ms} ms exit_code={exit_code}");
 
         Ok((duration_ms, begin_timestamp, exit_code, detected_phases))
     }

--- a/core/src/profiler/mod.rs
+++ b/core/src/profiler/mod.rs
@@ -203,10 +203,10 @@ impl JouleProfiler {
         let reader = BufReader::new(child_stdout);
         let mut detected_phases = Vec::with_capacity(2);
 
-        self.orchestrator.measure().await?;
-
         let begin_timestamp = get_timestamp_micros();
         trace!("Begin timestamp: {begin_timestamp}");
+
+        self.orchestrator.measure().await?;
 
         resume_process(pid)?;
 
@@ -235,9 +235,8 @@ impl JouleProfiler {
         let exit_code = wait_for_child_exit(&mut child)?;
 
         info!(
-            "Command finished: duration={} µs exit_code={}",
-            end_timestamp - begin_timestamp,
-            exit_code
+            "Command finished: duration={} ms exit_code={}",
+            duration_ms, exit_code
         );
 
         Ok((duration_ms, begin_timestamp, exit_code, detected_phases))

--- a/core/src/profiler/types.rs
+++ b/core/src/profiler/types.rs
@@ -20,10 +20,10 @@ pub struct Phase {
     /// Token marking the end of the phase.
     pub end_token: PhaseToken,
 
-    /// Start timestamp in milliseconds.
+    /// Start timestamp in microsecond.
     pub timestamp: u128,
 
-    /// Duration of the phase in milliseconds.
+    /// Duration of the phase in millisecond.
     pub duration_ms: u128,
 
     /// Optional start line number associated with the phase.
@@ -49,10 +49,10 @@ pub type Phases = Vec<Phase>;
 /// Represents the results of a program's profiling.
 #[derive(Debug, Serialize)]
 pub struct ProfilerResults {
-    /// Timestamp of the first measure in milliseconds.
+    /// Timestamp of the first measure in microsecond.
     pub timestamp: u128,
 
-    /// Duration of the program in milliseconds.
+    /// Duration of the program in millisecond.
     pub duration_ms: u128,
 
     /// Exit code of the profiled command.

--- a/core/src/util/fs.rs
+++ b/core/src/util/fs.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::util::time::get_timestamp_millis;
+use crate::util::time::get_timestamp_micros;
 
 /// Get the absolute path of a file.
 pub fn get_absolute_path(filename: &str) -> Result<String, std::io::Error> {
@@ -21,7 +21,7 @@ pub fn get_absolute_path(filename: &str) -> Result<String, std::io::Error> {
 
 /// Generates a default filename for results data.
 pub fn default_results_filename(ext: &str) -> String {
-    format!("data{}.{}", get_timestamp_millis(), ext)
+    format!("data{}.{}", get_timestamp_micros(), ext)
 }
 
 const URW_GRW_OR_PERMS: u32 = 0o664;

--- a/core/src/util/time.rs
+++ b/core/src/util/time.rs
@@ -1,9 +1,9 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Get the current system timestamp in microseconds.
-pub fn get_timestamp_millis() -> u128 {
+pub fn get_timestamp_micros() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or(Duration::from_secs(0))
-        .as_millis()
+        .as_micros()
 }

--- a/sources/rapl/src/perf/mod.rs
+++ b/sources/rapl/src/perf/mod.rs
@@ -65,9 +65,10 @@ impl Rapl {
         check_os()?;
 
         let paranoid_level = read_paranoid_level()?;
-        trace!("Perf paranoid level set to {paranoid_level}");
-
-        trace!("Attempting to initialize RAPL reader: sockets={sockets_spec:?}");
+        trace!(
+            "Perf paranoid level set to {paranoid_level}
+        Attempting to initialize RAPL reader: sockets={sockets_spec:?}"
+        );
 
         let sockets = discover_domains_and_open_counters(sockets_spec).map_err(|err| {
             if let RaplError::PerfParanoid(_) = err


### PR DESCRIPTION
The goal of this pull request is  to replace the timestamps in Joule Profiler from milliseconds to microseconds in order to provide a thiner granularity of phase timings. However, phases duration are still in milliseconds, the timestamps in microseconds are just an additional information that can be useful in some cases.